### PR TITLE
consolidate curse and curse timer to artifact creation

### DIFF
--- a/Projects/UOContent/Items/Jewels/Artifacts/OrnamentOfTheMagician.cs
+++ b/Projects/UOContent/Items/Jewels/Artifacts/OrnamentOfTheMagician.cs
@@ -4,10 +4,8 @@ using Server.Mobiles;
 namespace Server.Items
 {
     [SerializationGenerator(0, false)]
-    public partial class OrnamentOfTheMagician : GoldBracelet, ICursedItem
+    public partial class OrnamentOfTheMagician : GoldBracelet
     {
-        private readonly CursedItemHelper _curseHelper;
-
         [Constructible]
         public OrnamentOfTheMagician()
         {
@@ -17,11 +15,6 @@ namespace Server.Items
             Attributes.LowerManaCost = 10;
             Attributes.LowerRegCost = 20;
             Resistances.Energy = 15;
-
-            _curseHelper = new CursedItemHelper(this);
-            
-            // Start the curse timer immediately when the item is created
-            StartCurseTimer();
         }
 
         // Label number for "Ornament of the Magician"
@@ -29,26 +22,5 @@ namespace Server.Items
 
         // Rarity for the artifact system
         public override int ArtifactRarity => 11;
-
-        // Property to check if the item is currently cursed
-        public bool IsCursed => _curseHelper.IsCursed;
-
-        // Start the curse timer, which will last 5 minutes
-        public void StartCurseTimer()
-        {
-            _curseHelper.StartCurseTimer();
-        }
-
-        // Ends the curse and provides feedback to the player
-        public void EndCurse()
-        {
-            if (RootParent is Mobile owner)
-            {
-                owner.SendMessage("The curse on the artifact has faded.");
-            }
-        }
-
-        // Prevents the item from being insured while it is cursed
-        public override bool CanBeInsured => !IsCursed;
     }
 }

--- a/Projects/UOContent/Mobiles/Special/BaseChampion.cs
+++ b/Projects/UOContent/Mobiles/Special/BaseChampion.cs
@@ -55,6 +55,7 @@ public abstract partial class BaseChampion : BaseCreature
         {
             // Curse the artifact
             artifact.LootType = LootType.Cursed;
+            artifact.InvalidateProperties();
 
             // Start a 5 minute timer for the curse
             Timer.DelayCall(TimeSpan.FromMinutes(5), () =>

--- a/Projects/UOContent/Mobiles/Special/BaseChampion.cs
+++ b/Projects/UOContent/Mobiles/Special/BaseChampion.cs
@@ -51,10 +51,22 @@ public abstract partial class BaseChampion : BaseCreature
             statuette.Type = StatueTypes.RandomElement();
             statuette.LootType = LootType.Regular;
         }
-        
-        if (artifact is ICursedItem cursedArtifact)
+        else 
         {
-            cursedArtifact.StartCurseTimer(); // Apply the curse immediately
+            // Curse the artifact
+            artifact.LootType = LootType.Cursed;
+
+            // Start a 5 minute timer for the curse
+            Timer.DelayCall(TimeSpan.FromMinutes(5), () =>
+            {
+                // After 5 minutes, remove the curse
+                artifact.LootType = LootType.Regular;
+                artifact.InvalidateProperties();
+                if (artifact.RootParent is Mobile owner)
+                {
+                    owner.SendMessage("The curse on the item has faded.");
+                }
+            });
         }
 
         return artifact;
@@ -266,13 +278,12 @@ public abstract partial class BaseChampion : BaseCreature
             }
         }
 
-    // New Code: Attempt to generate an artifact
-    var artifact = GetArtifact();
-    if (artifact != null)
-    {
-        c.DropItem(artifact); 
-    }
-
+        // Attempt to generate an artifact
+        var artifact = GetArtifact();
+        if (artifact != null)
+        {
+            c.DropItem(artifact);
+        }
         base.OnDeath(c);
     }
 


### PR DESCRIPTION
Ignoring `CursedItemHelper` and `ICursedItem` for now.. this just consolidates all our curse timer logic to the `BaseChampion`'s `CreateArtifact` function.

- Create the artifact
- If its not a `MonsterStatuette`
   - Set it to Cursed
   - Start a timer for 5 mins
   - After 5 mins
      - Set the item to Normal and alert the owner

I'm still not 100% sure on C# convention/design patterns yet. There may be a cleaner or more robust way to handle this via your `CursedItemHelper` and `ICursedItem`, Im just not convinced we need it yet. If we don't, I'll remove those classes/interfaces in a future PR.